### PR TITLE
Don't require old version of platform

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "jquery": "~2.1.1",
     "backbone": "~1.1.2",
     "backbone.marionette": "~2.0.1",
-    "core-tooltip": "polymer/core-tooltip#~0.3.3",
-    "platform": "~1.2.0"
+    "core-tooltip": "polymer/core-tooltip#~0.3.3"
   }
 }


### PR DESCRIPTION
Pulling in core-tooltip will also pull in the latest version of polymer and platform.js
